### PR TITLE
chaseschelthoff/sc-41092/fix-pre-commit-openapi-failures-due-to-incompatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name='pre_commit_dummy_package',
     version='0.0.0',
-    install_requires=['openapi-spec-validator==0.4.0'],
+    install_requires=[
+        'jsonschema==3.2.0', 
+        'openapi-spec-validator==0.4.0'
+    ],
     scripts=['bin/check-many-openapi'],
 )


### PR DESCRIPTION
Pin `jsonschema` to `3.2.0` to address bug with error message like:

```
ImportError: cannot import name '_legacy_validators' from 'jsonschema' (/Users/chase/.cache/pre-commit/repoubzsu6_i/py_env-python3.10/lib/python3.10/site-packages/jsonschema/__init__.py)
```