### PR TITLE
Upgrade openapi-spec-validator to 0.7.1 (~20-40x faster validation) [sc-74431]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ setup(
     name='pre_commit_dummy_package',
     version='0.0.0',
     install_requires=[
-        'jsonschema==3.2.0', 
-        'openapi-spec-validator==0.4.0'
+        'openapi-spec-validator==0.7.1'
     ],
     scripts=['bin/check-many-openapi'],
 )


### PR DESCRIPTION
## What

Bump `openapi-spec-validator` `0.4.0` → `0.7.1` (and drop the now-conflicting `jsonschema==3.2.0` pin — 0.7.1 pulls jsonschema 4.x itself) in `setup.py`.

## Why

The pinned `0.4.0` / `jsonschema 3.2.0` have no `$ref`-resolution caching, so validating an aggregator spec is super-linear. In the `peach` repo, `openapi/api.yml` (refs all 49 domain files) takes **~21s** to validate; it changes in nearly every openapi-touching commit, so the "Validate OpenAPI schema" pre-commit hook is painfully slow.

With `0.7.1` (jsonschema 4.x ref caching) that same file validates in **~0.5s** — roughly **40x** faster.

## Notes

- 0.7.1 is also stricter: it validates `default` values against their schema. This surfaces a few latent schema bugs in `peach` (list default on a string field, `default: null` on non-nullable / enum fields) which are fixed in the companion peach PR before bumping the `rev`.
- Verified end-to-end with `pre-commit try-repo` against this branch: the hook passes on the peach openapi files (after the companion fixes).

After merge: tag and push `v0.0.4`, which the peach `.pre-commit-config.yaml` will point at.

Shortcut: sc-74431

🤖 Generated with [Claude Code](https://claude.com/claude-code)